### PR TITLE
Update to modern node-notifier and fix API call

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -1,5 +1,5 @@
 var path         = require('path');
-var Notification = require('node-notifier');
+var notifier     = require('node-notifier');
 
 module.exports = function Notifier() {
   this.notify_upload_and_copy_success = function(file) {
@@ -37,8 +37,6 @@ module.exports = function Notifier() {
   };
 
   this.notify = function(notification_params) {
-    var notification = new Notification();
-
-    notification.notify(notification_params);
+    notifier.notify(notification_params);
   };
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "aws-sdk": "~2.0.0-rc13",
-    "node-notifier": "git+ssh://git@github.com:ltk/node-notifier.git#e669a673d9af4d709a568ee67a94464d8e8a4231",
+    "node-notifier": "~4.6.1",
     "mime": "~1.2.0"
   },
   "readmeFilename": "README.md",


### PR DESCRIPTION
Fixes the notifications in OS X versions beyond El Capitan.
